### PR TITLE
Fixed routingKey issue during publish

### DIFF
--- a/src/rbccps/smartcity/IDEAM/APIs/RequestPublish.java
+++ b/src/rbccps/smartcity/IDEAM/APIs/RequestPublish.java
@@ -43,19 +43,14 @@ public class RequestPublish extends HttpServlet {
 		apikey = request.getHeader("apikey");
 		exchange = requestURI[1];
 		
-		String routingKey;
-		
 		try
 		{
 			routingKey=request.getHeader("routingKey");
 		}
 		catch(Exception e)
 		{
-			System.out.println("Routing key not specified");
-		}
-		finally
-		{
 			routingKey="#";
+			
 		}
 		
 		token=X_Consumer_Username+":"+apikey;


### PR DESCRIPTION
Routing key was always set to '#' since it was inside finally block. 