### PR TITLE
New features for entity owners, updated data access and control features 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,13 @@
 		<jersey.version>1.18.3</jersey.version>
 	</properties>
 	<dependencies>
+	
+		<dependency>
+    		<groupId>javax.ws.rs</groupId>
+    		<artifactId>javax.ws.rs-api</artifactId>
+    		<version>2.0</version>
+		</dependency>
+	
 		<dependency>
 			<groupId>com.rabbitmq</groupId>
 			<artifactId>amqp-client</artifactId>

--- a/src/rbccps/smartcity/IDEAM/APIs/RequestBind.java
+++ b/src/rbccps/smartcity/IDEAM/APIs/RequestBind.java
@@ -64,19 +64,26 @@ public class RequestBind extends HttpServlet
 		String exchange=request.getRequestURI().split("/")[4];
 		
 		String routingKey;
-	
+		jsonObject = new JsonObject();
+		
 		routingKey=request.getHeader("routingKey");
+		System.out.println(routingKey);
 		
 		if(routingKey== null)
 		{
 			routingKey="#";
+		} else if (! routingKey.equals("#")) {
+			response.setStatus(401);
+			jsonObject.addProperty("status", "Failure");
+			jsonObject.addProperty("reason", "You do not have access to bind this routingKey to the queue");
+			response.getWriter().println(jsonObject);
+			return;
 		}
 		
 
 		String username=request.getHeader("X-Consumer-Username");
 		String apikey=request.getHeader("Apikey");
 	
-		jsonObject = new JsonObject();
 		
 		decoded_authorization_datas[0] = request.getHeader("X-Consumer-Username");
 		decoded_authorization_datas[1] = request.getHeader("apikey");
@@ -214,12 +221,18 @@ public class RequestBind extends HttpServlet
 		String exchange=request.getRequestURI().split("/")[4];
 		
 		String routingKey;
-		
+		jsonObject = new JsonObject();
 		routingKey=request.getHeader("routingKey");
 		
 		if(routingKey== null)
 		{
 			routingKey="#";
+		} else if (! routingKey.equals("#")) {
+			response.setStatus(401);
+			jsonObject.addProperty("status", "Failure");
+			jsonObject.addProperty("reason", "You do not have access to unbind this routingKey to the queue");
+			response.getWriter().println(jsonObject);
+			return;
 		}
 		
 		String username=request.getHeader("X-Consumer-Username");
@@ -229,8 +242,7 @@ public class RequestBind extends HttpServlet
 		{
 			apikey=request.getParameter("apikey");
 		}
-		
-		jsonObject = new JsonObject();
+				
 		
 		decoded_authorization_datas[0] = request.getHeader("X-Consumer-Username");
 		decoded_authorization_datas[1] = request.getHeader("apikey");

--- a/src/rbccps/smartcity/IDEAM/APIs/RequestBind.java
+++ b/src/rbccps/smartcity/IDEAM/APIs/RequestBind.java
@@ -9,6 +9,7 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.google.gson.JsonObject;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
@@ -36,6 +37,7 @@ public class RequestBind extends HttpServlet
 	
 	static String[] decoded_authorization_datas = new String[2];
 	static boolean isOwner = false;
+	static JsonObject jsonObject;
 	
 	public void readldappwd() {
 		
@@ -73,6 +75,8 @@ public class RequestBind extends HttpServlet
 
 		String username=request.getHeader("X-Consumer-Username");
 		String apikey=request.getHeader("Apikey");
+	
+		jsonObject = new JsonObject();
 		
 		decoded_authorization_datas[0] = request.getHeader("X-Consumer-Username");
 		decoded_authorization_datas[1] = request.getHeader("apikey");
@@ -88,7 +92,9 @@ public class RequestBind extends HttpServlet
 						if(!username.equalsIgnoreCase(queue.split("\\.")[0]))
 							{
 								response.setStatus(401);
-								response.getWriter().println("You do not have access to bind this queue");
+								jsonObject.addProperty("status", "Failure");
+								jsonObject.addProperty("reason", "You do not have access to bind this queue");
+								response.getWriter().println(jsonObject);
 								return;
 							}
 		
@@ -101,12 +107,16 @@ public class RequestBind extends HttpServlet
 				Map<String, Object> args=new HashMap<String, Object>();
 				args.put("durable", "true");
 				Pool.getAdminChannel().queueBind(queue,exchange,routingKey,args);
-				response.getWriter().println("Bind Queue OK");
+				jsonObject.addProperty("status", "success");
+				jsonObject.addProperty("info", "Bind Queue OK");
+				response.getWriter().println(jsonObject);
 			}
 			catch(Exception e)
 			{
 				e.printStackTrace();
-				response.getWriter().println("Unable to bind queue");
+				jsonObject.addProperty("status", "Failure");
+				jsonObject.addProperty("reason", "Unable to bind queue");
+				response.getWriter().println(jsonObject);
 			}
 		}
 		else
@@ -140,7 +150,9 @@ public class RequestBind extends HttpServlet
 			} 
 			catch (NamingException e1) 
 			{
-				response.getWriter().println("Share entry does not exist");
+				jsonObject.addProperty("status", "Failure");
+				jsonObject.addProperty("reason", "Share entry does not exist");
+				response.getWriter().println(jsonObject);
 				return;
 			}
 			
@@ -162,18 +174,24 @@ public class RequestBind extends HttpServlet
 							args.put("durable", "true");
 							
 							Pool.getAdminChannel().queueBind(queue,exchange,routingKey,args);
-							response.getWriter().println("Bind Queue OK");
+							jsonObject.addProperty("status", "success");
+							jsonObject.addProperty("info", "Bind Queue OK");
+							response.getWriter().println(jsonObject);
 							break;
 						}
 						catch(Exception e)
 						{
 							e.printStackTrace();
-							response.getWriter().println("Unable to bind queue");
+							jsonObject.addProperty("status", "Failure");
+							jsonObject.addProperty("reason", "Unable to bind queue");
+							response.getWriter().println(jsonObject);
 						}
 				   }
 				   else
 				   {
-					   response.getWriter().println("Your data lease time has expired");
+					   jsonObject.addProperty("status", "Failure");
+					   jsonObject.addProperty("reason", "Your data lease time has expired");
+					   response.getWriter().println(jsonObject);
 				   }
 				}
 				
@@ -212,13 +230,15 @@ public class RequestBind extends HttpServlet
 			apikey=request.getParameter("apikey");
 		}
 		
+		jsonObject = new JsonObject();
+		
 		decoded_authorization_datas[0] = request.getHeader("X-Consumer-Username");
 		decoded_authorization_datas[1] = request.getHeader("apikey");
 
 					if ((LDAP.verifyProvider(queue, decoded_authorization_datas))) {
 								System.out.println("Device belongs to owner");
 								isOwner = true;
-								username = queue;
+								username = queue;	
 							}
 
 
@@ -226,7 +246,9 @@ public class RequestBind extends HttpServlet
 						if(!username.equalsIgnoreCase(queue.split("\\.")[0]))
 						{
 							response.setStatus(401);
-							response.getWriter().println("You do not have access to unbind this queue");
+							jsonObject.addProperty("status", "Failure");
+							jsonObject.addProperty("reason", "You do not have access to unbind this queue");
+							response.getWriter().println(jsonObject);
 							return;
 						}
 		
@@ -238,13 +260,17 @@ public class RequestBind extends HttpServlet
 				Map<String, Object> args=new HashMap<String, Object>();
 				args.put("durable", "true");
 				Pool.getAdminChannel().queueUnbind(queue,exchange,routingKey,args);
-				response.getWriter().println("Unbind Queue OK");
+				jsonObject.addProperty("status", "success");
+				jsonObject.addProperty("info", "Unbind Queue OK");
+				response.getWriter().println(jsonObject);
 			}
 			
 			catch(Exception e)
 			{
 				e.printStackTrace();
-				response.getWriter().println("Unable to unbind queue");
+				jsonObject.addProperty("status", "Failure");
+				jsonObject.addProperty("reason", "Unable to unbind queue");
+				response.getWriter().println(jsonObject);
 			}
 		}
 		else
@@ -287,14 +313,18 @@ public class RequestBind extends HttpServlet
 				Map<String, Object> args=new HashMap<String, Object>();
 				args.put("durable", "true");
 				Pool.getAdminChannel().queueUnbind(queue,exchange,routingKey,args);
-				response.getWriter().println("Unbind Queue OK");
+				jsonObject.addProperty("status", "success");
+				jsonObject.addProperty("info", "Unbind Queue OK");
+				response.getWriter().println(jsonObject);
 				ctx.close();
 			}
 			
 			catch(Exception e)
 			{
 				e.printStackTrace();
-				response.getWriter().println("Unable to unbind queue");
+				jsonObject.addProperty("status", "Failure");
+				jsonObject.addProperty("reason", "Unable to unbind queue");
+				response.getWriter().println(jsonObject);
 			}
 			
 		}

--- a/src/rbccps/smartcity/IDEAM/APIs/RequestBind.java
+++ b/src/rbccps/smartcity/IDEAM/APIs/RequestBind.java
@@ -14,6 +14,7 @@ import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
 
 import rbccps.smartcity.IDEAM.registerapi.broker.Pool;
+import rbccps.smartcity.IDEAM.registerapi.ldap.LDAP;
 
 import javax.naming.Context;
 import javax.naming.NamingEnumeration;
@@ -32,6 +33,9 @@ public class RequestBind extends HttpServlet
 {
 	static String ldap_pwd;
 	static String rmq_pwd;
+	
+	static String[] decoded_authorization_datas = new String[2];
+	static boolean isOwner = false;
 	
 	public void readldappwd() {
 		
@@ -70,13 +74,23 @@ public class RequestBind extends HttpServlet
 		String username=request.getHeader("X-Consumer-Username");
 		String apikey=request.getHeader("Apikey");
 		
-		
-		if(!username.equalsIgnoreCase(queue.split("\\.")[0]))
-		{
-			response.setStatus(401);
-			response.getWriter().println("You do not have access to bind this queue");
-			return;
-		}
+		decoded_authorization_datas[0] = request.getHeader("X-Consumer-Username");
+		decoded_authorization_datas[1] = request.getHeader("apikey");
+
+					if ((LDAP.verifyProvider(queue, decoded_authorization_datas))) {
+								System.out.println("Device belongs to owner");
+								isOwner = true;
+								username = queue;
+							}
+
+
+					if (!isOwner)
+						if(!username.equalsIgnoreCase(queue.split("\\.")[0]))
+							{
+								response.setStatus(401);
+								response.getWriter().println("You do not have access to bind this queue");
+								return;
+							}
 		
 		//If the exchange and queue belongs to the same device
 		
@@ -198,12 +212,23 @@ public class RequestBind extends HttpServlet
 			apikey=request.getParameter("apikey");
 		}
 		
-		if(!username.equalsIgnoreCase(queue.split("\\.")[0]))
-		{
-			response.setStatus(401);
-			response.getWriter().println("You do not have access to unbind this queue");
-			return;
-		}
+		decoded_authorization_datas[0] = request.getHeader("X-Consumer-Username");
+		decoded_authorization_datas[1] = request.getHeader("apikey");
+
+					if ((LDAP.verifyProvider(queue, decoded_authorization_datas))) {
+								System.out.println("Device belongs to owner");
+								isOwner = true;
+								username = queue;
+							}
+
+
+					if (!isOwner)
+						if(!username.equalsIgnoreCase(queue.split("\\.")[0]))
+						{
+							response.setStatus(401);
+							response.getWriter().println("You do not have access to unbind this queue");
+							return;
+						}
 		
 		
 		if(queue.split("\\.")[0].equalsIgnoreCase(exchange.split("\\.")[0]))

--- a/src/rbccps/smartcity/IDEAM/APIs/RequestBind.java
+++ b/src/rbccps/smartcity/IDEAM/APIs/RequestBind.java
@@ -104,6 +104,11 @@ public class RequestBind extends HttpServlet
 								response.getWriter().println(jsonObject);
 								return;
 							}
+					
+					System.out.println(username + "   ====   " + apikey + "   ====   " + isOwner);
+					
+					isOwner = false;
+					
 		
 		//If the exchange and queue belongs to the same device
 		
@@ -157,6 +162,7 @@ public class RequestBind extends HttpServlet
 			} 
 			catch (NamingException e1) 
 			{
+				response.setStatus(404);
 				jsonObject.addProperty("status", "Failure");
 				jsonObject.addProperty("reason", "Share entry does not exist");
 				response.getWriter().println(jsonObject);
@@ -196,6 +202,7 @@ public class RequestBind extends HttpServlet
 				   }
 				   else
 				   {
+					   response.setStatus(401);
 					   jsonObject.addProperty("status", "Failure");
 					   jsonObject.addProperty("reason", "Your data lease time has expired");
 					   response.getWriter().println(jsonObject);
@@ -264,8 +271,9 @@ public class RequestBind extends HttpServlet
 							return;
 						}
 		
+					isOwner = false;
 		
-		if(queue.split("\\.")[0].equalsIgnoreCase(exchange.split("\\.")[0]))
+		if(queue.split("\\.")[0].equalsIgnoreCase(exchange.split("\\.")[0])||(exchange.split("\\.")[1].equalsIgnoreCase("public")))
 		{
 			try 
 			{
@@ -317,6 +325,9 @@ public class RequestBind extends HttpServlet
 			catch (NamingException e1) 
 			{
 				response.setStatus(401);
+				jsonObject.addProperty("status", "Failure");
+				jsonObject.addProperty("reason", "Share entry does not exist");
+				response.getWriter().println(jsonObject);
 				return;
 			}
 

--- a/src/rbccps/smartcity/IDEAM/APIs/RequestFollow.java
+++ b/src/rbccps/smartcity/IDEAM/APIs/RequestFollow.java
@@ -30,6 +30,7 @@ import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
 
 import rbccps.smartcity.IDEAM.registerapi.broker.Pool;
+import rbccps.smartcity.IDEAM.registerapi.ldap.LDAP;
 import rbccps.smartcity.IDEAM.registerapi.lora.loraserverConfigurationFields;
 
 /**
@@ -70,6 +71,9 @@ public class RequestFollow extends HttpServlet {
 	static String rmq_pwd;
 	static String ldap_pwd;
 	
+	static String[] decoded_authorization_datas = new String[2];
+	static boolean isOwner = false;
+	
 	public void readldappwd() 
 	{	
 		try
@@ -93,11 +97,20 @@ public class RequestFollow extends HttpServlet {
 			body = request.getReader().lines().collect(Collectors.joining(System.lineSeparator()));
 			boolean flag = getfollowInfo(body);
 			
-			if(!request.getHeader("X-Consumer-Username").equals(_requestorID))
-			{
-				response.setStatus(401);
-				return;
-			}
+			decoded_authorization_datas[0] = request.getHeader("X-Consumer-Username");
+			decoded_authorization_datas[1] = request.getHeader("apikey");
+
+				if ((LDAP.verifyProvider(_requestorID, decoded_authorization_datas))) {
+							System.out.println("Device belongs to owner");
+							isOwner = true;
+						}
+
+				if (!isOwner)
+					if(!request.getHeader("X-Consumer-Username").equals(_requestorID))
+						{
+						response.setStatus(401);
+						return;
+						}
 			
 			if(!flag)
 			{
@@ -133,11 +146,20 @@ public class RequestFollow extends HttpServlet {
 		
 		boolean flag = getfollowInfo(body);
 		
-		if(!request.getHeader("X-Consumer-Username").equals(_requestorID))
-		{
-			response.setStatus(401);
-			return;
-		}
+		decoded_authorization_datas[0] = request.getHeader("X-Consumer-Username");
+		decoded_authorization_datas[1] = request.getHeader("apikey");
+
+			if ((LDAP.verifyProvider(_requestorID, decoded_authorization_datas))) {
+						System.out.println("Device belongs to owner");
+						isOwner = true;
+					}
+
+			if (!isOwner)
+				if(!request.getHeader("X-Consumer-Username").equals(_requestorID))
+					{
+						response.setStatus(401);
+						return;
+					}
 		
 		if(!flag)
 		{

--- a/src/rbccps/smartcity/IDEAM/APIs/RequestFollow.java
+++ b/src/rbccps/smartcity/IDEAM/APIs/RequestFollow.java
@@ -97,6 +97,8 @@ public class RequestFollow extends HttpServlet {
 			body = request.getReader().lines().collect(Collectors.joining(System.lineSeparator()));
 			boolean flag = getfollowInfo(body);
 			
+			jsonObject = new JsonObject();
+			
 			decoded_authorization_datas[0] = request.getHeader("X-Consumer-Username");
 			decoded_authorization_datas[1] = request.getHeader("apikey");
 
@@ -115,7 +117,9 @@ public class RequestFollow extends HttpServlet {
 			if(!flag)
 			{
 				response.setStatus(400);
-				response.getWriter().println("Possible missing fields");
+				jsonObject.addProperty("status", "Failure");
+				jsonObject.addProperty("reason", "Possible missing fields");
+				response.getWriter().println(jsonObject);
 				return;
 			}
 			
@@ -132,7 +136,9 @@ public class RequestFollow extends HttpServlet {
 		catch (IOException e) 
 		{
 			response.setStatus(400);
-			response.getWriter().println("Invalid request");
+			jsonObject.addProperty("status", "Failure");
+			jsonObject.addProperty("reason", "Invalid request");
+			response.getWriter().println(jsonObject);
 			return;
 		}
 	}
@@ -145,6 +151,7 @@ public class RequestFollow extends HttpServlet {
 		body = request.getReader().lines().collect(Collectors.joining(System.lineSeparator()));
 		
 		boolean flag = getfollowInfo(body);
+		jsonObject = new JsonObject();
 		
 		decoded_authorization_datas[0] = request.getHeader("X-Consumer-Username");
 		decoded_authorization_datas[1] = request.getHeader("apikey");
@@ -164,7 +171,9 @@ public class RequestFollow extends HttpServlet {
 		if(!flag)
 		{
 			response.setStatus(502);
-			response.getWriter().println("Internal server error");
+			jsonObject.addProperty("status", "Failure");
+			jsonObject.addProperty("reason", "Internal server error");
+			response.getWriter().println(jsonObject);
 		}
 		
 		Hashtable<String, Object> env = new Hashtable<String, Object>();
@@ -196,7 +205,9 @@ public class RequestFollow extends HttpServlet {
 				if(!unbind)
 				{
 					response.setStatus(502);
-					response.getWriter().println("Unable to unbind queue");
+					jsonObject.addProperty("status", "Failure");
+					jsonObject.addProperty("reason", "Unable to unbind queue");
+					response.getWriter().println(jsonObject);					
 				}
 			}
 			else if(_permission.equals("write"))
@@ -214,15 +225,23 @@ public class RequestFollow extends HttpServlet {
 				if(!unbind)
 				{
 					response.setStatus(502);
-					response.getWriter().println("Unable to unbind queue");
+					jsonObject.addProperty("status", "Failure");
+					jsonObject.addProperty("reason", "Unable to unbind queue");
+					response.getWriter().println(jsonObject);
 				}
 			}
 			
-			response.getWriter().println("Successfully unfollowed "+_entityID);
+			jsonObject.addProperty("status", "success");
+			jsonObject.addProperty("info", "Successfully unfollowed");
+			jsonObject.addProperty("entityID", _entityID);
+			response.getWriter().println(jsonObject);
+		
 		}
 		catch (NamingException e1) 
 		{
-			response.getWriter().println("Share entry does not exist");
+			jsonObject.addProperty("status", "failure");
+			jsonObject.addProperty("reason", "Share entry does not exist");
+			response.getWriter().println(jsonObject);
 			return;
 		}
 	}

--- a/src/rbccps/smartcity/IDEAM/APIs/RequestFollow.java
+++ b/src/rbccps/smartcity/IDEAM/APIs/RequestFollow.java
@@ -138,6 +138,8 @@ public class RequestFollow extends HttpServlet {
 						return;
 						}
 			
+				isOwner = false;
+				
 			if(!flag)
 			{
 				response.setStatus(400);
@@ -208,6 +210,8 @@ public class RequestFollow extends HttpServlet {
 						return;
 					}
 		
+			isOwner = false;
+			
 		if(!flag)
 		{
 			response.setStatus(502);

--- a/src/rbccps/smartcity/IDEAM/APIs/RequestShare.java
+++ b/src/rbccps/smartcity/IDEAM/APIs/RequestShare.java
@@ -371,11 +371,17 @@ public class RequestShare extends HttpServlet
 		JsonObject response=new JsonObject();
 		if(ldap&&pub)
 		{
-			response.addProperty("status","Share request approved for "+_requestorID+" with permission "+_permission+" at "+Instant.now());
+			response.addProperty("status","success");
+			response.addProperty("info","Share request approved");
+			response.addProperty("entityID",_requestorID);
+			response.addProperty("permission",_permission);
+			response.addProperty("validity",_validity);
+		
 		}
 		else 
 		{
-			response.addProperty("status", "Failed to approve share request");
+			response.addProperty("status","failure");
+			response.addProperty("reason", "Failed to approve share request");
 		}
 		
 		return response.toString();
@@ -388,7 +394,9 @@ public class RequestShare extends HttpServlet
 		{	
 			JsonObject object=new JsonObject();
 			
-			object.addProperty("Status update for follow request sent to "+entityID, "Approved. You can now bind to "+entityID+".protected");
+			object.addProperty("status","Approved");
+			object.addProperty("info","You can now bind to "+entityID+".protected");
+		
 			
 			Pool.getAdminChannel().basicPublish(requestorID+".notify", "#", null, object.toString().getBytes("UTF-8"));
 			

--- a/src/rbccps/smartcity/IDEAM/APIs/RequestShare.java
+++ b/src/rbccps/smartcity/IDEAM/APIs/RequestShare.java
@@ -85,6 +85,9 @@ public class RequestShare extends HttpServlet
 	static String rmq_pwd;
 	static String ldap_pwd;
 	
+	static String[] decoded_authorization_datas = new String[2];
+	static boolean isOwner = false;
+	
 	public static void readldappwd() 
 	{	
 		try
@@ -109,11 +112,20 @@ public class RequestShare extends HttpServlet
 			
 			boolean flag = getshareinfo(body);
 			
-			if(!request.getHeader("X-Consumer-Username").equals(_entityID))
-			{
-				response.setStatus(401);
-				return;
+			decoded_authorization_datas[0] = request.getHeader("X-Consumer-Username");
+			decoded_authorization_datas[1] = request.getHeader("apikey");
+			
+			if ((LDAP.verifyProvider(_entityID, decoded_authorization_datas))) {
+				System.out.println("Device belongs to owner");
+				isOwner = true;
 			}
+
+			if (!isOwner)
+				if(!request.getHeader("X-Consumer-Username").equals(_entityID))
+					{
+						response.setStatus(401);
+						return;
+					}
 			
 			if(!flag)
 			{
@@ -148,11 +160,20 @@ public class RequestShare extends HttpServlet
 		
 		boolean flag = getshareinfo(body);
 		
-		if(!request.getHeader("X-Consumer-Username").equals(_entityID))
-		{
-			response.setStatus(401);
-			return;
+		decoded_authorization_datas[0] = request.getHeader("X-Consumer-Username");
+		decoded_authorization_datas[1] = request.getHeader("apikey");
+		
+		if ((LDAP.verifyProvider(_entityID, decoded_authorization_datas))) {
+			System.out.println("Device belongs to owner");
+			isOwner = true;
 		}
+
+		if (!isOwner)
+			if(!request.getHeader("X-Consumer-Username").equals(_entityID))
+			{
+				response.setStatus(401);
+				return;
+			}
 		
 		if(!flag)
 		{

--- a/src/rbccps/smartcity/IDEAM/APIs/RequestShare.java
+++ b/src/rbccps/smartcity/IDEAM/APIs/RequestShare.java
@@ -112,6 +112,8 @@ public class RequestShare extends HttpServlet
 			
 			boolean flag = getshareinfo(body);
 			
+			jsonObject = new JsonObject();
+			
 			decoded_authorization_datas[0] = request.getHeader("X-Consumer-Username");
 			decoded_authorization_datas[1] = request.getHeader("apikey");
 			
@@ -130,7 +132,9 @@ public class RequestShare extends HttpServlet
 			if(!flag)
 			{
 				response.setStatus(400);
-				response.getWriter().println("Possible missing fields");
+				jsonObject.addProperty("status", "Failure");
+				jsonObject.addProperty("reason", "Possible missing fields");
+				response.getWriter().println(jsonObject);
 				return;
 			}
 			
@@ -160,6 +164,8 @@ public class RequestShare extends HttpServlet
 		
 		boolean flag = getshareinfo(body);
 		
+		jsonObject = new JsonObject();
+		
 		decoded_authorization_datas[0] = request.getHeader("X-Consumer-Username");
 		decoded_authorization_datas[1] = request.getHeader("apikey");
 		
@@ -178,7 +184,9 @@ public class RequestShare extends HttpServlet
 		if(!flag)
 		{
 			response.setStatus(400);
-			response.getWriter().println("Possible missing fields");
+			jsonObject.addProperty("status", "Failure");
+			jsonObject.addProperty("reason", "Possible missing fields");
+			response.getWriter().println(jsonObject);
 			return;
 		}
 		
@@ -211,7 +219,10 @@ public class RequestShare extends HttpServlet
 				if(!unbind)
 				{
 					response.setStatus(502);
-					response.getWriter().println("Unable to unbind queue");
+					jsonObject.addProperty("status", "Failure");
+					jsonObject.addProperty("reason", "Unable to unbind queue");
+					response.getWriter().println(jsonObject);
+					
 				}
 			}
 			else if(_permission.equals("write"))
@@ -229,19 +240,26 @@ public class RequestShare extends HttpServlet
 				if(!unbind)
 				{
 					response.setStatus(502);
-					response.getWriter().println("Unable to unbind queue");
+					jsonObject.addProperty("status", "Failure");
+					jsonObject.addProperty("reason", "Unable to unbind queue");
+					response.getWriter().println(jsonObject);
+					
 				}
 			}
 		}
 		
 		catch (NamingException e1) 
 		{
-			response.getWriter().println("Share entry does not exist");
+			jsonObject.addProperty("status", "Failure");
+			jsonObject.addProperty("reason", "Share entry does not exist");
+			response.getWriter().println(jsonObject);
 			return;
 		}
 		
-		response.getWriter().println("Successfully unshared from "+_requestorID);
-		
+		jsonObject.addProperty("status", "success");
+		jsonObject.addProperty("reason", "Successfully unshared");
+		jsonObject.addProperty("entityID", _requestorID);
+		response.getWriter().println(jsonObject);
 	}
 	
 	public boolean getshareinfo(String json) 

--- a/src/rbccps/smartcity/IDEAM/APIs/RequestShare.java
+++ b/src/rbccps/smartcity/IDEAM/APIs/RequestShare.java
@@ -146,11 +146,13 @@ public class RequestShare extends HttpServlet
 			}
 
 			if (!isOwner)
-				if(!request.getHeader("X-Consumer-Username").equals(_entityID))
+				if(!request.getHeader("X-Consumer-Username").equals(share_entityID))
 					{
 						response.setStatus(401);
 						return;
 					}
+			
+			isOwner = false;
 			
 			if(!flag)
 			{
@@ -211,17 +213,19 @@ public class RequestShare extends HttpServlet
 		decoded_authorization_datas[0] = request.getHeader("X-Consumer-Username");
 		decoded_authorization_datas[1] = request.getHeader("apikey");
 		
-		if ((LDAP.verifyProvider(_entityID, decoded_authorization_datas))) {
+		if ((LDAP.verifyProvider(share_entityID, decoded_authorization_datas))) {
 			System.out.println("Device belongs to owner");
 			isOwner = true;
 		}
 
 		if (!isOwner)
-			if(!request.getHeader("X-Consumer-Username").equals(_entityID))
+			if(!request.getHeader("X-Consumer-Username").equals(share_entityID))
 			{
 				response.setStatus(401);
 				return;
 			}
+		
+		isOwner = false;
 		
 		if(!flag)
 		{

--- a/src/rbccps/smartcity/IDEAM/registerapi/broker/broker.java
+++ b/src/rbccps/smartcity/IDEAM/registerapi/broker/broker.java
@@ -155,7 +155,7 @@ public class broker {
 	}
 
 	
-	public static String publish(String _entityID, String _permission, String _requestorID, String _validity) 
+	public static String publish(String _entityID, String _permission, String _requestorID, String _validity, String _exchange) 
 	{
 		
 		JsonObject response=new JsonObject();
@@ -165,16 +165,18 @@ public class broker {
 			JsonObject object=new JsonObject();
 			
 			object.addProperty("requestor", _requestorID);
+			object.addProperty("access", _exchange);
 			object.addProperty("permission", _permission);
 			object.addProperty("validity", _validity);
 			_timestamp = Instant.now().toString();
 			object.addProperty("timestamp", _timestamp);
 
-			Pool.getAdminChannel().basicPublish(_entityID, "#", null, object.toString().getBytes("UTF-8"));
+			Pool.getAdminChannel().basicPublish(_entityID+".follow", _entityID + "." +_exchange, null, object.toString().getBytes("UTF-8"));
 			
 			response.addProperty("status", "success");
 			response.addProperty("info", "Follow request has been made");
 			response.addProperty("entityID", _entityID);
+			response.addProperty("access", _exchange);
 			response.addProperty("permission", _permission);
 			response.addProperty("timestamp", _timestamp);
 			

--- a/src/rbccps/smartcity/IDEAM/registerapi/broker/broker.java
+++ b/src/rbccps/smartcity/IDEAM/registerapi/broker/broker.java
@@ -30,6 +30,7 @@ public class broker {
 	static String response;
 	static String password = "";
 	static String _message;
+	static String _timestamp;
 
 
 	public static String createExchange(String resourceID) 
@@ -166,11 +167,16 @@ public class broker {
 			object.addProperty("requestor", _requestorID);
 			object.addProperty("permission", _permission);
 			object.addProperty("validity", _validity);
-			object.addProperty("timestamp", Instant.now().toString());
+			_timestamp = Instant.now().toString();
+			object.addProperty("timestamp", _timestamp);
 
 			Pool.getAdminChannel().basicPublish(_entityID, "#", null, object.toString().getBytes("UTF-8"));
 			
-			response.addProperty("status","Follow request has been made to "+_entityID+" with permission "+_permission+" at "+Instant.now());
+			response.addProperty("status", "success");
+			response.addProperty("info", "Follow request has been made");
+			response.addProperty("entityID", _entityID);
+			response.addProperty("permission", _permission);
+			response.addProperty("timestamp", _timestamp);
 			
 			return response.toString();
 		}
@@ -178,7 +184,8 @@ public class broker {
 		catch(Exception e)
 		{
 			e.printStackTrace();
-			response.addProperty("status","Failed to make follow request");
+			response.addProperty("status","failure");
+			response.addProperty("reason","Failed to make follow request");
 		}
 		
 		return response.toString();

--- a/src/rbccps/smartcity/IDEAM/registerapi/ldap/LDAP.java
+++ b/src/rbccps/smartcity/IDEAM/registerapi/ldap/LDAP.java
@@ -47,6 +47,7 @@ public class LDAP {
 	static String brokerShareEntryDN;
 	static String brokerShare_Name_EntryDN;
 	static String LDAPEntry;
+	public static boolean entryexists = false;
 
 	public static void readldappwd() {
 		System.out.println("constructer to LDAP bind");
@@ -760,6 +761,12 @@ public class LDAP {
 			catch (Exception e) 
 			{
 				System.out.println("error: " + e.getMessage());
+				
+				if (e.getMessage().toString().contains("Entry Already Exists"))
+				{
+					entryexists = true;
+				}
+				
 				return flag;
 			}
 			
@@ -787,6 +794,13 @@ public class LDAP {
 			catch (Exception e) 
 			{
 				System.out.println("error: " + e.getMessage());
+				
+				if (e.getMessage().toString().contains("Entry Already Exists"))
+				{
+					entryexists = true;
+				}
+					
+				
 				return flag;
 			}
 		}
@@ -825,6 +839,11 @@ public class LDAP {
 			catch (Exception e) 
 			{
 				System.out.println("error: " + e.getMessage());
+				if (e.getMessage().toString().contains("Entry Already Exists"))
+				{
+					entryexists = true;
+				}
+					
 				return flag;
 			}
 		}

--- a/src/rbccps/smartcity/IDEAM/registerapi/ldap/LDAP.java
+++ b/src/rbccps/smartcity/IDEAM/registerapi/ldap/LDAP.java
@@ -722,7 +722,7 @@ public class LDAP {
 	}
 	
 	// Attributes to be set for new entry creation
-	public boolean addShareEntry(String providerId, String userId, String permission, String validity) {
+	public boolean addShareEntry(String providerId, String userId, String permission, String validity, String _exchange) {
 		boolean flag = false;
 		//System.out.println(providerId + " : " + userId + " : " + read + " : " + write  + " : " + validity);
 
@@ -741,7 +741,7 @@ public class LDAP {
 		
 		if(permission.equals("read"))
 		{
-			brokerShareEntryDN = "description="+providerId+".protected,description=read,description=share,description=broker,uid="
+			brokerShareEntryDN = "description="+providerId+"."+_exchange+",description=read,description=share,description=broker,uid="
 					+ userId + ",cn=devices,dc=smartcity";
 
 			brokerShareEntry = new BasicAttributes();
@@ -806,7 +806,7 @@ public class LDAP {
 		}
 		else if(permission.equals("read-write"))
 		{
-			String brokerReadShareEntryDN = "description="+providerId+".protected,description=read,description=share,description=broker,uid="
+			String brokerReadShareEntryDN = "description="+providerId+"."+_exchange+",description=read,description=share,description=broker,uid="
 					+ userId + ",cn=devices,dc=smartcity";
 
 			Attributes brokerReadShareEntry = new BasicAttributes();


### PR DESCRIPTION
- Feature : Entity Owner can now share, un-share, follow, un-follow, bind and unbind on behalf of entity
- Update : Entity share, un-share, follow, un-follow, bind and unbind responses are now completely in JSON
- Feature : Entities and Owners can now share, un-share, follow, un-follow, bind and unbind with private, heartbeat and protected channels
- Update : LDAP can now allow sharing of private, heartbeat and protected channels
- Bug-Fix : Binding and un-binding can now be done only for routingKey=#. This stops user from getting data even after unsharing.

